### PR TITLE
FEAT: Update Paramiko to 3.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 singer-python==5.9.0
-paramiko==2.6.0
+paramiko==3.4.0
 backoff==1.8.0
 terminaltables==3.1.0
 python-gnupg==0.4.6


### PR DESCRIPTION
- Updates Paramiko to 3.4.0 to use preferred algortihms for ssh for UPS PIC TRK data
- https://teepublic.atlassian.net/browse/DE-2072